### PR TITLE
feat : Added CVE check in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    branches: ["*"]
     paths:
       - 'src/**'
       - 'Cargo.toml'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/check.yml'
+      - '.gitignore'
 
 jobs:
   lint: 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    branches: ["*"]
     paths:
       - 'Dockerfile'
       - '.dockerignore'

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ${{ steps.meta.outputs.tags }}
+        image-ref: ${{ steps.push.outputs.buildx.ref }}
         format: 'sarif'
         exit-code: '0'
         ignore-unfixed: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -55,6 +55,7 @@ jobs:
         tags: |
           type=raw,value=latest,enable={{is_default_branch}}
           type=ref,event=tag
+          type=sha
 
     - name: Build Docker image and push on main
       id: push

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -62,6 +62,7 @@ jobs:
       uses: docker/build-push-action@v6.15.0
       with:
         push: false
+        load: true
         context: .
         file: ./Dockerfile
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -58,7 +58,7 @@ jobs:
           type=sha
 
     - name: Build Docker image and push on main
-      id: push
+      id: build
       uses: docker/build-push-action@v6.15.0
       with:
         push: false
@@ -87,6 +87,7 @@ jobs:
         sarif_file: 'trivy-results.sarif'
 
     - name: Push
+      id: push
       if: ${{ steps.meta.outputs.tags != '' }}
       run:
         echo "Pushing image to registry"
@@ -96,6 +97,6 @@ jobs:
       uses: actions/attest-build-provenance@v2.2.3
       if: ${{ steps.meta.outputs.tags != '' }}
       with:
-        subject-name: ${{ steps.meta.outputs.tags }}
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         subject-digest: ${{ steps.push.outputs.digest }}
         push-to-registry: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ${{ steps.push.outputs.buildx.ref }}
+        image-ref: ${{ steps.push.outputs.image.name }}
         format: 'sarif'
         exit-code: '0'
         ignore-unfixed: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -71,20 +71,18 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: '${{ env.IMAGE_NAME }}:latest'
-        format: 'json'
-        exit-code: '1'
+        image-ref: ${{ steps.meta.outputs.tags }}
+        format: 'sarif'
+        exit-code: '0'
         ignore-unfixed: true
         vuln-type: 'os,library'
-        output: 'trivy-report.json'
+        output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH'
 
-    - name: Upload Vulnerability Scan Results
-      uses: actions/upload-artifact@v4
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
       with:
-        name: trivy-report
-        path: trivy-report.json
-        retention-days: 30
+        sarif_file: 'trivy-results.sarif'
 
     - name: Push
       if: ${{ steps.meta.outputs.tags != '' }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -96,6 +96,6 @@ jobs:
       uses: actions/attest-build-provenance@v2.2.3
       if: ${{ steps.meta.outputs.tags != '' }}
       with:
-        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        subject-name: ${{ steps.meta.outputs.tags }}
         subject-digest: ${{ steps.push.outputs.digest }}
         push-to-registry: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -14,7 +14,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
 
-
 jobs:
   build_docker:
     name: Docker build
@@ -60,13 +59,37 @@ jobs:
       id: push
       uses: docker/build-push-action@v6.15.0
       with:
-        push: ${{ steps.meta.outputs.tags != '' }}
+        push: false
         context: .
         file: ./Dockerfile
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: '${{ env.IMAGE_NAME }}:latest'
+        format: 'json'
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: 'os,library'
+        output: 'trivy-report.json'
+        severity: 'CRITICAL,HIGH'
+
+    - name: Upload Vulnerability Scan Results
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-report
+        path: trivy-report.json
+        retention-days: 30
+
+    - name: Push
+      if: ${{ steps.meta.outputs.tags != '' }}
+      run:
+        echo "Pushing image to registry"
+        docker push -a ${{ steps.meta.outputs.tags }}
 
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v2.2.3

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -9,10 +9,12 @@ on:
       - main
     paths:
       - 'Dockerfile'
+      - '.dockerignore'
       - '.github/workflows/docker_build.yml'
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.gitignore'
 
 jobs:
   build_docker:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -92,11 +92,3 @@ jobs:
       run: |
         echo "Pushing image to registry"
         echo ${{ steps.meta.outputs.tags }} | xargs -n1 docker push
-
-    - name: Generate artifact attestation
-      uses: actions/attest-build-provenance@v2.2.3
-      if: ${{ steps.meta.outputs.tags != '' }}
-      with:
-        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        subject-digest: ${{ steps.push.outputs.digest }}
-        push-to-registry: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Push
       id: push
       if: ${{ steps.meta.outputs.tags != '' }}
-      run:
+      run: |
         echo "Pushing image to registry"
         echo ${{ steps.meta.outputs.tags }} | xargs -n1 docker push
 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ${{ steps.push.outputs.image.name }}
+        image-ref: ${{ steps.meta.outputs.tags }}
         format: 'sarif'
         exit-code: '0'
         ignore-unfixed: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -90,7 +90,7 @@ jobs:
       if: ${{ steps.meta.outputs.tags != '' }}
       run:
         echo "Pushing image to registry"
-        docker push -a ${{ steps.meta.outputs.tags }}
+        echo ${{ steps.meta.outputs.tags }} | xargs -n1 docker push
 
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v2.2.3


### PR DESCRIPTION
This pull request includes updates to the Docker build workflow to enhance security and improve the build process. The most important changes include adding a vulnerability scanner, modifying the push behavior, and uploading scan results.

Security enhancements:

* [`.github/workflows/docker_build.yml`](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bL63-R93): Added `Run Trivy vulnerability scanner` step to scan the Docker image for vulnerabilities and generate a report in JSON format.
* [`.github/workflows/docker_build.yml`](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bL63-R93): Added `Upload Vulnerability Scan Results` step to upload the Trivy scan report as an artifact with a retention period of 30 days.

Build process improvements:

* [`.github/workflows/docker_build.yml`](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bL63-R93): Modified the `push` parameter in the `docker/build-push-action` step to always be `false` to prevent automatic pushing of the Docker image.
* [`.github/workflows/docker_build.yml`](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bL63-R93): Added a new `Push` step to manually push the Docker image to the registry if tags are present.

Minor cleanup:

* [`.github/workflows/docker_build.yml`](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bL17): Removed an unnecessary blank line in the file.