### PR TITLE
fix : Switch docker image push with trivy scan

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -57,7 +57,7 @@ jobs:
           type=ref,event=tag
           type=sha
 
-    - name: Build Docker image and push on main
+    - name: Build Docker image
       id: build
       uses: docker/build-push-action@v6.15.0
       with:
@@ -70,17 +70,15 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-    - name: Push
-      id: push
-      if: ${{ steps.meta.outputs.tags != '' }}
+    - name: Extract first image ID
+      id: image_id
       run: |
-        echo "Pushing image to registry"
-        echo ${{ steps.meta.outputs.tags }} | xargs -n1 docker push
+        echo "IMAGE_ID=$(echo ${{ steps.meta.outputs.tags }} | cut -d ',' -f 1)" >> $GITHUB_ENV
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ${{ steps.meta.outputs.tags }}
+        image-ref: ${{ env.IMAGE_ID }}
         format: 'sarif'
         exit-code: '0'
         ignore-unfixed: true
@@ -92,3 +90,10 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
+
+    - name: Push
+      id: push
+      if: ${{ steps.meta.outputs.tags != '' }}
+      run: |
+        echo "Pushing image to registry"
+        echo ${{ steps.meta.outputs.tags }} | xargs -n1 docker push

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -70,6 +70,13 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
+    - name: Push
+      id: push
+      if: ${{ steps.meta.outputs.tags != '' }}
+      run: |
+        echo "Pushing image to registry"
+        echo ${{ steps.meta.outputs.tags }} | xargs -n1 docker push
+
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
@@ -85,10 +92,3 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
-
-    - name: Push
-      id: push
-      if: ${{ steps.meta.outputs.tags != '' }}
-      run: |
-        echo "Pushing image to registry"
-        echo ${{ steps.meta.outputs.tags }} | xargs -n1 docker push


### PR DESCRIPTION
This pull request modifies the `.github/workflows/docker_build.yml` file to adjust the order of steps in the GitHub Actions workflow. The primary change involves moving the "Push" step to an earlier point in the workflow, before the Trivy vulnerability scanner step.

Workflow adjustments:

* Moved the "Push" step (which pushes Docker images to the registry) to occur before the Trivy vulnerability scanner step. This ensures the image is pushed earlier in the workflow if applicable. (`.github/workflows/docker_build.yml`, [[1]](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bR73-R79) [[2]](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bL88-L94)